### PR TITLE
Fix TPLCBlockElement.WriteFaultCallback don't notify HMI controls

### DIFF
--- a/src/scada/plcblockelement.pas
+++ b/src/scada/plcblockelement.pas
@@ -254,9 +254,10 @@ end;
 
 procedure TPLCBlockElement.SetValueRaw(aValue:Double);
 begin
-  if Assigned(PBlock) then
-    PBlock.ValueRaw[PIndex] := aValue
-  else
+  if Assigned(PBlock) then begin
+    PBlock.ValueRaw[PIndex] := aValue;
+    PValueRaw := aValue;
+  end else
     if PValueRaw<>Value then begin
       PValueRaw:=Value;
       NotifyChange;
@@ -266,7 +267,9 @@ end;
 function TPLCBlockElement.ScanRead: Int64;
 begin
   if Assigned(PBlock) then
-    Result:=PBlock.ScanRead;
+    Result:=PBlock.ScanRead
+  else
+    Result:=-1;
 end;
 
 function TPLCBlockElement.ScanWrite(Values: TArrayOfDouble; Count,


### PR DESCRIPTION
Hi Fabio, thank you for nice library!

When using TPLCBlock and HMI controls connected to it via TPLCBlockElement, I found that when the user changes the HMI control and a subsequent write error occurs, the control state does not return to the previous state.

When using TPLCTagNumber, everything works correctly as expected.

When studying the source code, it was found that in TPLCBlockElement.SetValueRaw(), the PValueRaw value is not updated, and when calling WriteFaultCallback(), PValueRaw is compared with the value stored in PBlock.ValueRaw[PIndex] and the notification does not work.