### PR TITLE
** Fixed THMIBasicColletion.Assign on BlinkWith feature

### DIFF
--- a/src/hmi/hmibasiccolletion.pas
+++ b/src/hmi/hmibasiccolletion.pas
@@ -7,6 +7,8 @@ uses
 
 type
 
+  { THMIBasicColletion }
+
   THMIBasicColletion = class(TCollection)
   private
     FOwner:TPersistent;
@@ -23,6 +25,7 @@ type
  public
    //: @exclude
    function GetComponentState:TComponentState;
+   procedure Assign(Source: TPersistent); override;
  public
 
     {$IFDEF PORTUGUES}
@@ -159,6 +162,31 @@ function THMIBasicColletion.GetComponentState: TComponentState;
 begin
   NeedCurrentCompState;
   Result := FComponentState;
+end;
+
+procedure THMIBasicColletion.Assign(Source: TPersistent);
+var
+  I: Integer;
+begin
+  If Source is THMIBasicColletion then
+    begin
+    BeginUpdate;
+    try
+      Clear;
+      For I:=0 To THMIBasicColletion(Source).Count-1 do
+       Add;
+
+      For I:=0 To Self.Count-1 do begin
+       Items[I].Assign(THMIBasicColletion(Source).Items[I]);
+       DoOnChange(Self.Items[I]);
+      end;
+    finally
+      EndUpdate;
+    end;
+    exit;
+    end
+  else
+    Inherited Assign(Source);
 end;
 
 procedure THMIBasicColletion.NeedCurrentCompState;

--- a/src/hmi/hmizones.pas
+++ b/src/hmi/hmizones.pas
@@ -566,6 +566,9 @@ type
   @seealso(TGraphicZones)
   }
   {$ENDIF}
+
+  { TGraphicZone }
+
   TGraphicZone = class(TAnimationZone)
   private
      FILIsDefault:Boolean;
@@ -583,6 +586,7 @@ type
   public
      //: @exclude
      constructor Create(aCollection: TCollection); override;
+     procedure Assign(Source: TPersistent); override;
   published
 
      {$IFDEF PORTUGUES}
@@ -698,6 +702,9 @@ type
   @seealso(TGraphicZone)
   }
   {$ENDIF}
+
+  { TGraphicZones }
+
   TGraphicZones = class(TZones)
   public
     //: @exclude
@@ -1294,6 +1301,27 @@ begin
    FImageList := nil;
    FImageIndex := -1;
    FColor := clWhite;
+end;
+
+procedure TGraphicZone.Assign(Source: TPersistent);
+var
+  Src: TGraphicZone;
+begin
+  if Source is TGraphicZone then begin
+     Src:=Source as TGraphicZone;
+
+     FValue1      := Src.FValue1;
+     FValue2      := Src.FValue2;
+     FIncludeV1   := Src.FIncludeV1;
+     FIncludeV2   := Src.FIncludeV2;
+     FDefaultZone := Src.FDefaultZone;
+     FZoneType    := Src.FZoneType;
+     FImageList   := Src.FImageList;
+     FImageIndex  := Src.FImageIndex;
+     FBlinkTime   := Src.FBlinkTime;
+     BlinkWith    := Src.BlinkWith;
+  end else
+    inherited Assign(Source);
 end;
 
 procedure TGraphicZone.SetILAsDefault(b:Boolean);


### PR DESCRIPTION
Added an override on the THMIBasicColletion.Assign function to first add the itens then associate the blinkWith property to the existent pointer.